### PR TITLE
Remove missing 'color' module that made build fail

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -1,5 +1,3 @@
-import Color from 'color';
-
 import { Platform } from 'react-native';
 
 export default {


### PR DESCRIPTION
This module is not installed, causing the build to fail. However, it is also not used in this file. Therefore it can safely be removed.