### PR TITLE
Fix for picker

### DIFF
--- a/src/fields/picker/index.js
+++ b/src/fields/picker/index.js
@@ -24,11 +24,11 @@ export default class PickerField extends Component {
     if (Platform.OS !== 'ios') {
       return (
         <View
-          style={Object.assign(styles.pickerMainAndroid, {
+          style={{...styles.pickerMainAndroid, ...{
             backgroundColor: theme.pickerBgColor,
             borderBottomColor: theme.inputBorderColor,
             borderBottomWidth: theme.borderWidth,
-          })}
+          }}}
         >
           <View style={{ flex: 7 }}>
             <Text style={{ color: theme.inputColorPlaceholder }}>{attributes.label}</Text>


### PR DESCRIPTION
This is a fix for issue #16 and #12.

The code causes the error. [picker/index.js#L27](https://github.com/bietkul/react-native-form-builder/blob/master/src/fields/picker/index.js#L27)
```js
Object.assign(styles.pickerMainAndroid, {
 backgroundColor: theme.pickerBgColor,
 borderBottomColor: theme.inputBorderColor,
 borderBottomWidth: theme.borderWidth,
})
```

I found two ways to prevent this error.
```
Error : You attempted to set the key backgroundcolor with the value "transparent"
on an object that is meant to be immutables and has been frozen.
```

**A. Using Spread Operator (...)** (This is what i used)
```jsx
<View
  style={{...styles.pickerMainAndroid, ...{
    backgroundColor: theme.pickerBgColor,
    borderBottomColor: theme.inputBorderColor,
    borderBottomWidth: theme.borderWidth,
 }}}
>
```

**B. Using Object.assign()**
- The first parameter should be an empty object.

```jsx
<View
 style={Object.assign({}, styles.pickerMainAndroid, {
   backgroundColor: theme.pickerBgColor,
   borderBottomColor: theme.inputBorderColor,
   borderBottomWidth: theme.borderWidth,
})}
>
```