### PR TITLE
Replace deprecated react-native-i18n with moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
    "dependencies": {
       "fs-extra": "^3.0.1",
       "lodash": "^4.17.4",
+      "moment": "^2.24.0",
       "print-message": "^2.1.0",
       "prop-types": "^15.6.0",
-      "react-native-i18n": "^2.0.0",
       "react-native-keyboard-aware-scroll-view": "^0.8.0"
    },
    "devDependencies": {

--- a/src/fields/date/index.js
+++ b/src/fields/date/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { View, Text } from 'native-base';
-import I18n from 'react-native-i18n';
+import moment from 'moment';
 import { Platform, DatePickerIOS, DatePickerAndroid, TouchableOpacity, TimePickerAndroid } from 'react-native';
 import Panel from '../../components/panel';
 
@@ -113,7 +113,7 @@ export default class DatePickerField extends Component {
                   }}
                 >
                   <Text>
-                    { (value && I18n.strftime(value, '%d %b %Y')) || 'None' }
+                    { (value && moment(value).format('ll')) || 'None' }
                   </Text>
                 </View>
             }
@@ -128,7 +128,7 @@ export default class DatePickerField extends Component {
                   }}
                 >
                   <Text>
-                    { (value && I18n.strftime(value, '%I:%M %p')) || 'None' }
+                    { (value && moment(value).format('LT')) || 'None' }
                   </Text>
                 </View>
             }
@@ -180,7 +180,7 @@ export default class DatePickerField extends Component {
                   }}
                 >
                   <Text onPress={this.showDatePicker}>
-                    { (value && I18n.strftime(value, '%d %b %Y')) || 'Date' }
+                    { (value && moment(value).format('ll')) || 'Date' }
                   </Text>
                 </TouchableOpacity>
             }
@@ -194,7 +194,7 @@ export default class DatePickerField extends Component {
                 }}
               >
                 <Text onPress={this.showTimePicker}>
-                  { (value && I18n.strftime(value, '%I:%M %p')) || 'Time' }
+                  { (value && moment(value).format('LT')) || 'Time' }
                 </Text>
                 </TouchableOpacity>
             }


### PR DESCRIPTION
As [react-native-i18n](https://github.com/AlexanderZaytsev/react-native-i18n) is deprecated and throws an error of not resolveable _RNI18n.languages_ I recommend to replace it with `moment`. In addition it uses the localized format.

<img src="https://user-images.githubusercontent.com/18537755/67592277-9bd6a500-f75f-11e9-857c-70b4ae092b35.png" width="150">
